### PR TITLE
Support React.Fragment

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -52,6 +52,16 @@ export default function render(
   // children -> elements, everything else are attributes
   const { children, ...rest } = props
   const attributes = stringifyAttributes(rest)
+  const isFragment = name === Symbol.for('react.fragment')
+  const childIndent = isFragment ? indent : indent + INDENTATION
+
+  const strChildren = isArray(children)
+    ? children.map((item) => render(item, childIndent))
+    : [render(children, childIndent)]
+
+  if (isFragment) {
+    return strChildren
+  }
 
   const str = [indent === 0 ? '' : `\n`]
 
@@ -60,10 +70,6 @@ export default function render(
       attributes.length === 0 ? '' : ' '
     }${attributes}>`,
   )
-
-  const strChildren = isArray(children)
-    ? children.map((item) => render(item, indent + INDENTATION))
-    : [render(children, indent + INDENTATION)]
 
   str.push(...strChildren)
 


### PR DESCRIPTION
When I use React.Fragment, This error appears:

```
TypeError: Cannot convert a Symbol value to a string
    at render (/Users/yuki/.ghq/github.com/mottox2/jsx-presentation/node_modules/react-xml/dist/bundle.cjs.js:84:17)
    at children.map.item (/Users/yuki/.ghq/github.com/mottox2/jsx-presentation/node_modules/react-xml/dist/bundle.cjs.js:76:64)
    at Array.map (<anonymous>)
    at render (/Users/yuki/.ghq/github.com/mottox2/jsx-presentation/node_modules/react-xml/dist/bundle.cjs.js:76:52)
    at children.map.item (/Users/yuki/.ghq/github.com/mottox2/jsx-presentation/node_modules/react-xml/dist/bundle.cjs.js:76:64)
    at Array.map (<anonymous>)
    at render (/Users/yuki/.ghq/github.com/mottox2/jsx-presentation/node_modules/react-xml/dist/bundle.cjs.js:76:52)
    at children.map.item (/Users/yuki/.ghq/github.com/mottox2/jsx-presentation/node_modules/react-xml/dist/bundle.cjs.js:76:64)
    at Array.map (<anonymous>)
    at render (/Users/yuki/.ghq/github.com/mottox2/jsx-presentation/node_modules/react-xml/dist/bundle.cjs.js:76:52)
```

So, I wrote a code to check React.Fragment.